### PR TITLE
amazon-ecr-credential-helper v0.8.0

### DIFF
--- a/amazon-ecr-credential-helper/amazon-ecr-credential-helper.nuspec
+++ b/amazon-ecr-credential-helper/amazon-ecr-credential-helper.nuspec
@@ -26,7 +26,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>0.7.1</version>
+    <version>0.8.0</version>
     <owners>GiSeong Eom</owners>
     <packageSourceUrl>https://github.com/giseongeom/chocolatey-packages/tree/master/amazon-ecr-credential-helper/</packageSourceUrl>
     <!-- <packageSourceUrl>Where is this Chocolatey package located (think GitHub)? packageSourceUrl is highly recommended for the community feed</packageSourceUrl>-->

--- a/amazon-ecr-credential-helper/amazon-ecr-credential-helper.nuspec
+++ b/amazon-ecr-credential-helper/amazon-ecr-credential-helper.nuspec
@@ -26,7 +26,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>0.7.0</version>
+    <version>0.7.1</version>
     <owners>GiSeong Eom</owners>
     <packageSourceUrl>https://github.com/giseongeom/chocolatey-packages/tree/master/amazon-ecr-credential-helper/</packageSourceUrl>
     <!-- <packageSourceUrl>Where is this Chocolatey package located (think GitHub)? packageSourceUrl is highly recommended for the community feed</packageSourceUrl>-->

--- a/amazon-ecr-credential-helper/amazon-ecr-credential-helper.nuspec
+++ b/amazon-ecr-credential-helper/amazon-ecr-credential-helper.nuspec
@@ -26,7 +26,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>0.6.0</version>
+    <version>0.7.0</version>
     <owners>GiSeong Eom</owners>
     <packageSourceUrl>https://github.com/giseongeom/chocolatey-packages/tree/master/amazon-ecr-credential-helper/</packageSourceUrl>
     <!-- <packageSourceUrl>Where is this Chocolatey package located (think GitHub)? packageSourceUrl is highly recommended for the community feed</packageSourceUrl>-->

--- a/amazon-ecr-credential-helper/tools/chocolateyinstall.ps1
+++ b/amazon-ecr-credential-helper/tools/chocolateyinstall.ps1
@@ -8,8 +8,8 @@ $packageArgs = @{
     FileFullPath = $fileFullPath
 
     # 64-bit
-    url64          = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.6.0/windows-amd64/docker-credential-ecr-login.exe'
-    checksum64     = '3356E38A20566D688AC6ED22A9999ECCA4559ED56EEC4D402430B581CAE84BB9'
+    url64          = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.7.0/windows-amd64/docker-credential-ecr-login.exe'
+    checksum64     = '634e35d502f42a279117c99fd7562d3c17d304ce8a01ea11e4e2353d5a17b080'
     checksumType64 = 'sha256'
 }
 

--- a/amazon-ecr-credential-helper/tools/chocolateyinstall.ps1
+++ b/amazon-ecr-credential-helper/tools/chocolateyinstall.ps1
@@ -8,8 +8,8 @@ $packageArgs = @{
     FileFullPath = $fileFullPath
 
     # 64-bit
-    url64          = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.7.0/windows-amd64/docker-credential-ecr-login.exe'
-    checksum64     = '634e35d502f42a279117c99fd7562d3c17d304ce8a01ea11e4e2353d5a17b080'
+    url64          = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.7.1/windows-amd64/docker-credential-ecr-login.exe'
+    checksum64     = '60dd759f6c333ac12b5447470a4e26553d39c9288765771e5e264daa135f46b2'
     checksumType64 = 'sha256'
 }
 

--- a/amazon-ecr-credential-helper/tools/chocolateyinstall.ps1
+++ b/amazon-ecr-credential-helper/tools/chocolateyinstall.ps1
@@ -8,8 +8,8 @@ $packageArgs = @{
     FileFullPath = $fileFullPath
 
     # 64-bit
-    url64          = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.7.1/windows-amd64/docker-credential-ecr-login.exe'
-    checksum64     = '60dd759f6c333ac12b5447470a4e26553d39c9288765771e5e264daa135f46b2'
+    url64          = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.8.0/windows-amd64/docker-credential-ecr-login.exe'
+    checksum64     = 'eb385f5c69dd62087a9c59cbade8feeb47bd9c8ec2addb84b4427dda8d704201'
     checksumType64 = 'sha256'
 }
 


### PR DESCRIPTION
This supersedes #10 and should be merged instead if the maintainers are only interested in the most up-to-date version of the helper.